### PR TITLE
OP-1003 - removed requests_toolbelt package from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 python-dateutil
 requests
-requests_toolbelt
 setuptools_scm
 python-dotenv


### PR DESCRIPTION
 removed requests_toolbelt package from requirements (used anymore -> last used with FingerprintAdapter)